### PR TITLE
to return dataframe with datetime index

### DIFF
--- a/pypoloniex/TimeSeries.py
+++ b/pypoloniex/TimeSeries.py
@@ -93,7 +93,7 @@ class TimeSeries(object):
 		
 		#make DataFrame with datetime index
 		tempdf=pd.DataFrame(data, columns = fields)
-		tempdf.index=pd.to_datetime(tempdf['date'])
+		tempdf.index=pd.to_datetime(tempdf['date'], dayfirst=True)
 		tempdf.drop('date', axis=1, inplace=True)
 		
 		self.data = tempdf

--- a/pypoloniex/TimeSeries.py
+++ b/pypoloniex/TimeSeries.py
@@ -91,7 +91,12 @@ class TimeSeries(object):
 					row.append(dtp[fld])
 			data.append(row)
 		
-		self.data = pd.DataFrame(data, columns = fields)
+		#make DataFrame with datetime index
+		tempdf=pd.DataFrame(data, columns = fields)
+		tempdf.index=pd.to_datetime(tempdf['date'])
+		tempdf.drop('date', axis=1, inplace=True)
+		
+		self.data = tempdf
 		self.empty = False
 		self.pair = pair
 		self.period = period


### PR DESCRIPTION
proposal to modify to return dataframe with datetime index, instead of having a separate column. Easier for analysis, plotting, etc